### PR TITLE
Fix: collection item element not responding to scrolling in touch inp…

### DIFF
--- a/HyPlayer/Controls/PlaylistItem.xaml
+++ b/HyPlayer/Controls/PlaylistItem.xaml
@@ -13,7 +13,8 @@
     <Grid
         CornerRadius="8"
         PointerEntered="UIElement_OnPointerEntered"
-        PointerExited="UIElement_OnPointerExited">
+        PointerExited="UIElement_OnPointerExited"
+        PointerCaptureLost="UIElement_OnPointerCaptureLost">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition />

--- a/HyPlayer/Controls/PlaylistItem.xaml.cs
+++ b/HyPlayer/Controls/PlaylistItem.xaml.cs
@@ -54,6 +54,11 @@ namespace HyPlayer.Controls
             StoryboardIn.Begin();
         }
 
+        private void UIElement_OnPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+        {
+            StoryboardIn.Begin();
+        }
+
         private async void PlayAllBtn_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             //播放全部歌曲

--- a/HyPlayer/Controls/SingleAlbum.xaml
+++ b/HyPlayer/Controls/SingleAlbum.xaml
@@ -11,11 +11,12 @@
 
     <Grid
         x:Name="Grid1"
+        BorderThickness="1"
         Tapped="Grid1_OnTapped"
         DoubleTapped="Grid1_OnDoubleTapped"
         PointerEntered="UIElement_OnPointerEntered"
-        BorderThickness="1"
-        PointerExited="Grid1_OnPointerExited">
+        PointerExited="Grid1_OnPointerExited"
+        PointerCaptureLost="Grid1_OnPointerCaptureLost">
         <Grid.ColumnDefinitions>
             <ColumnDefinition
                 Width="30" />

--- a/HyPlayer/Controls/SingleAlbum.xaml.cs
+++ b/HyPlayer/Controls/SingleAlbum.xaml.cs
@@ -57,7 +57,11 @@ namespace HyPlayer.Controls
                 Application.Current.Resources["SystemControlBackgroundListMediumRevealBorderBrush"] as Brush;
         }
 
-        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e)
+        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void Grid1_OnPointerCaptureLost(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void SetUnfocusedState()
         {
             Grid1.Background = null;
             Grid1.BorderBrush = new SolidColorBrush();

--- a/HyPlayer/Controls/SingleArtist.xaml
+++ b/HyPlayer/Controls/SingleArtist.xaml
@@ -11,11 +11,12 @@
 
     <Grid
         x:Name="Grid1"
+        BorderThickness="1"
         Tapped="Grid1_OnTapped"
         DoubleTapped="Grid1_OnDoubleTapped"
         PointerEntered="UIElement_OnPointerEntered"
-        BorderThickness="1"
-        PointerExited="Grid1_OnPointerExited">
+        PointerExited="Grid1_OnPointerExited"
+        PointerCaptureLost="Grid1_OnPointerCaptureLost">
         <Grid.ColumnDefinitions>
             <ColumnDefinition
                 Width="30" />

--- a/HyPlayer/Controls/SingleArtist.xaml.cs
+++ b/HyPlayer/Controls/SingleArtist.xaml.cs
@@ -54,7 +54,11 @@ namespace HyPlayer.Controls
                 Application.Current.Resources["SystemControlBackgroundListMediumRevealBorderBrush"] as Brush;
         }
 
-        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e)
+        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void Grid1_OnPointerCaptureLost(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void SetUnfocusedState()
         {
             Grid1.Background = null;
             Grid1.BorderBrush = new SolidColorBrush();

--- a/HyPlayer/Controls/SingleNCSong.xaml
+++ b/HyPlayer/Controls/SingleNCSong.xaml
@@ -18,6 +18,7 @@
         DoubleTapped="Grid1_OnDoubleTapped"
         PointerEntered="UIElement_OnPointerEntered"
         PointerExited="Grid1_OnPointerExited"
+        PointerCaptureLost="Grid1_OnPointerCaptureLost"
         RightTapped="{x:Bind hyplayer:Common.UIElement_RightTapped}"
         Tapped="Grid1_OnTapped">
         <Grid.ColumnDefinitions>

--- a/HyPlayer/Controls/SingleNCSong.xaml.cs
+++ b/HyPlayer/Controls/SingleNCSong.xaml.cs
@@ -96,7 +96,14 @@ namespace HyPlayer.Controls
                 Application.Current.Resources["SystemControlBackgroundListMediumRevealBorderBrush"] as Brush;
         }
 
-        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e)
+        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        // When scrolling in the collection control on a touchscreen-equipped device with pointer
+        // inside the control, PointerCaptureLost event instead of PointerExited event gets triggered.
+        // Handling both of the events would fix the styling issue in this situation.
+        private void Grid1_OnPointerCaptureLost(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void SetUnfocusedState()
         {
             Grid1.Background = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0));
             Grid1.BorderBrush = new SolidColorBrush();

--- a/HyPlayer/Controls/SinglePlaylistStack.xaml
+++ b/HyPlayer/Controls/SinglePlaylistStack.xaml
@@ -11,11 +11,12 @@
 
     <Grid
         x:Name="Grid1"
+        BorderThickness="1"
         Tapped="Grid1_OnTapped"
         DoubleTapped="Grid1_OnDoubleTapped"
         PointerEntered="UIElement_OnPointerEntered"
-        BorderThickness="1"
-        PointerExited="Grid1_OnPointerExited">
+        PointerExited="Grid1_OnPointerExited"
+        PointerCaptureLost="Grid1_OnPointerCaptureLost">
         <Grid.ColumnDefinitions>
             <ColumnDefinition
                 Width="30" />

--- a/HyPlayer/Controls/SinglePlaylistStack.xaml.cs
+++ b/HyPlayer/Controls/SinglePlaylistStack.xaml.cs
@@ -53,7 +53,11 @@ namespace HyPlayer.Controls
                 Application.Current.Resources["SystemControlBackgroundListMediumRevealBorderBrush"] as Brush;
         }
 
-        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e)
+        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void Grid1_OnPointerCaptureLost(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void SetUnfocusedState()
         {
             Grid1.Background = null;
             Grid1.BorderBrush = new SolidColorBrush();

--- a/HyPlayer/Controls/SingleRadio.xaml
+++ b/HyPlayer/Controls/SingleRadio.xaml
@@ -11,11 +11,12 @@
 
     <Grid
         x:Name="Grid1"
+        BorderThickness="1"
         Tapped="Grid1_OnTapped"
         DoubleTapped="Grid1_OnDoubleTapped"
         PointerEntered="UIElement_OnPointerEntered"
-        BorderThickness="1"
-        PointerExited="Grid1_OnPointerExited">
+        PointerExited="Grid1_OnPointerExited"
+        PointerCaptureLost="Grid1_OnPointerCaptureLost">
         <Grid.ColumnDefinitions>
             <ColumnDefinition
                 Width="30" />

--- a/HyPlayer/Controls/SingleRadio.xaml.cs
+++ b/HyPlayer/Controls/SingleRadio.xaml.cs
@@ -40,7 +40,11 @@ namespace HyPlayer.Controls
                 Application.Current.Resources["SystemControlBackgroundListMediumRevealBorderBrush"] as Brush;
         }
 
-        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e)
+        private void Grid1_OnPointerExited(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void Grid1_OnPointerCaptureLost(object sender, PointerRoutedEventArgs e) => SetUnfocusedState();
+
+        private void SetUnfocusedState()
         {
             Grid1.Background = null;
             Grid1.BorderBrush = new SolidColorBrush();


### PR DESCRIPTION
…ut mode

When scrolling in the collection control on a touchscreen-equipped device with pointer inside the control, PointerCaptureLost event instead of PointerExited event gets triggered. Handling both events would fix the styling issue in this situation.