### PR TITLE
Optimized invoking logic for "Personal FM" and "Create Songlist" on BasePage

### DIFF
--- a/HyPlayer/Pages/BasePage.xaml
+++ b/HyPlayer/Pages/BasePage.xaml
@@ -50,6 +50,7 @@
             IsTitleBarAutoPaddingEnabled="False"
             PaneDisplayMode="Auto"
             PaneTitle="HyPlayer"
+            ItemInvoked="NavMain_ItemInvoked"
             SelectionChanged="NavMain_OnSelectionChanged">
             <muxc:NavigationView.AutoSuggestBox>
                 <AutoSuggestBox
@@ -100,7 +101,7 @@
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE734;" />
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
-                <muxc:NavigationViewItem Content="私人FM" Tag="PersonalFM">
+                <muxc:NavigationViewItem Content="私人FM" Tag="PersonalFM" SelectsOnInvoked="False">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEFA9;" />
                     </muxc:NavigationViewItem.Icon>
@@ -116,7 +117,8 @@
                     Content="创建歌单"
                     Icon="Add"
                     Tag="SonglistCreate"
-                    Visibility="Collapsed" />
+                    Visibility="Collapsed"
+                    SelectsOnInvoked="False" />
                 <muxc:NavigationViewItem
                     x:Name="NavItemsMyLovedPlaylist"
                     Content="我喜欢的音乐"


### PR DESCRIPTION
先前 "创建歌单" 的逻辑是菜单项被 invoke 后执行操作再导航到前一个页面，而 "私人FM" 完成后留下了导航视图指示器。将这两个命令式（而非导航式）菜单项单独处理也许更高效简洁。