### PR TITLE
新版Playbar(半成品，因能力有限存在大量Bug)

### DIFF
--- a/HyPlayer/Common.cs
+++ b/HyPlayer/Common.cs
@@ -170,7 +170,6 @@ namespace HyPlayer
             if (Setting.forceMemoryGarbage)
             {
                 if (NavigationHistory.Count >= 1 && PageBase.NavMain.SelectedItem == NavigationHistory.Peek().Item)
-                    PageBase.NavMain.SelectedItem = PageBase.NavItemBlank;
                 NavigationHistory.Push(new NavigationHistoryItem
                 {
                     PageType = SourcePageType,
@@ -188,7 +187,6 @@ namespace HyPlayer
             }
 
             if (previousNavigationItem == PageBase.NavMain.SelectedItem)
-                PageBase.NavMain.SelectedItem = PageBase.NavItemBlank;
             previousNavigationItem = PageBase.NavMain.SelectedItem;
         }
 

--- a/HyPlayer/Controls/PlayBar.xaml
+++ b/HyPlayer/Controls/PlayBar.xaml
@@ -211,6 +211,40 @@
             Fill="{ThemeResource SystemControlAltMediumLowAcrylicElementMediumBrush}"
             Visibility="{x:Bind hy:Common.Setting.playbarBackgroundAcrylic, Mode=OneWay}" />
         <Grid
+                x:Name="PlayProgress"
+                Grid.ColumnSpan="3"
+            Margin="115,80,8,0"
+                HorizontalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                    x:Name="TextBlockTotalTime"
+                    Grid.Column="3"
+                    Margin="5,5,0,0"
+                    controls:DockPanel.Dock="Right" />
+            <Border Grid.Column="1" Padding="5,0,5,0">
+                <Slider
+                        x:Name="SliderProgress"
+                        Margin="-5,0,-5,0"
+                        ValueChanged="SliderProgress_ValueChanged">
+                    <Slider.ThumbToolTipValueConverter>
+                        <local:ThumbConverter SecondValue="{Binding SecondValue}" />
+
+                    </Slider.ThumbToolTipValueConverter>
+                </Slider>
+            </Border>
+            <TextBlock
+                    x:Name="TextBlockNowTime"
+                    Grid.Column="0"
+                    Margin="0,5,5,0"
+                    controls:DockPanel.Dock="Left" />
+
+        </Grid>
+
+        <Grid
             x:Name="GridSongInfoContainer"
             Grid.Column="0"
             Grid.ColumnSpan="2"
@@ -220,7 +254,7 @@
             CornerRadius="8,0,0,0">
             <StackPanel
                 x:Name="GridSongAdvancedOperation"
-                Margin="25,0,0,0"
+                Margin="25,-30,0,0"
                 Orientation="Horizontal"
                 Spacing="15"
                 Visibility="Collapsed">
@@ -233,7 +267,7 @@
                     CornerRadius="20"
                     Background="Transparent"
                     BorderBrush="Transparent">
-                    <FontIcon Glyph="&#xE972;" />
+                    <FontIcon Glyph="&#xE972;" FontSize="16" />
                 </Button>
                 <Button
                     x:Name="Btn_Sub"
@@ -245,7 +279,7 @@
                     Background="Transparent"
                     BorderBrush="Transparent"
                     ToolTipService.ToolTip="添加到歌单">
-                    <FontIcon Glyph="&#xE1DA;" />
+                    <FontIcon Glyph="&#xE1DA;" FontSize="16"/>
                 </Button>
                 <Button
                     x:Name="Btn_Down"
@@ -257,7 +291,7 @@
                     Background="Transparent"
                     BorderBrush="Transparent"
                     ToolTipService.ToolTip="下载音乐">
-                    <FontIcon Glyph="&#xE118;" />
+                    <FontIcon Glyph="&#xE118;" FontSize="16"/>
                 </Button>
                 <Button
                     x:Name="Btn_Comment"
@@ -270,7 +304,7 @@
                     BorderBrush="Transparent"
                     ToolTipService.ToolTip="查看评论"
                     Visibility="{x:Bind Mode=OneWay, Path=hy:Common.Setting.notClearMode}">
-                    <FontIcon Glyph="&#xE8F2;" />
+                    <FontIcon Glyph="&#xE8F2;" FontSize="16"/>
                 </Button>
                 <Button
                     x:Name="Btn_Share"
@@ -282,7 +316,7 @@
                     Background="Transparent"
                     BorderBrush="Transparent"
                     ToolTipService.ToolTip="分享">
-                    <FontIcon Glyph="&#xE72D;" />
+                    <FontIcon Glyph="&#xE72D;" FontSize="16" />
                 </Button>
             </StackPanel>
             <StackPanel
@@ -348,7 +382,7 @@
                     <Grid
                         x:Name="SongInfoTag"
                         Height="20"
-                        Margin="0,14,0,0"
+                        Margin="-115,20,0,0"
                         Padding="3,0,3,0"
                         HorizontalAlignment="Left"
                         BorderBrush="Red"
@@ -371,7 +405,8 @@
         <Grid
             x:Name="MainControlGrid"
             Grid.Column="1"
-            Margin="-80,5,-80,0"
+            Grid.ColumnSpan="2"
+            Margin="0,5,0,0"
             Canvas.ZIndex="0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="5*" />
@@ -385,11 +420,16 @@
                 Grid.Row="0"
                 Margin="0,5,0,0">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition x:Name="Blank" Width="6.5*"/>
                     <ColumnDefinition />
                     <ColumnDefinition />
                     <ColumnDefinition />
                     <ColumnDefinition />
                     <ColumnDefinition />
+                    <ColumnDefinition x:Name="Blank1" Width="0"  />
+                    <ColumnDefinition x:Name="Blank2" Width="0"  />
+                    <ColumnDefinition x:Name="Blank3" Width="0"  />
+                    <ColumnDefinition x:Name="Blank4" Width="0"  />
                     <ColumnDefinition />
                     <ColumnDefinition />
                     <ColumnDefinition />
@@ -397,7 +437,7 @@
                 </Grid.ColumnDefinitions>
                 <Button
                     x:Name="BtnMore"
-                    Grid.Column="0"
+                    Grid.Column="1"
                     Grid.ColumnSpan="3"
                     Width="40"
                     Height="40"
@@ -465,7 +505,7 @@
                 </Button>
                 <Button
                     x:Name="BtnPlayRollType"
-                    Grid.Column="2"
+                    Grid.Column="1"
                     Width="38"
                     Height="38"
                     HorizontalAlignment="Center"
@@ -477,12 +517,12 @@
                     ToolTipService.ToolTip="{x:Bind FlyoutPlayRollType.Text, Mode=OneWay}">
                     <FontIcon
                         x:Name="IconPlayType"
-                        FontSize="13"
+                        FontSize="14"
                         Glyph="&#xE169;" />
                 </Button>
                 <Button
                     x:Name="BtnPreviousSong"
-                    Grid.Column="3"
+                    Grid.Column="2"
                     Width="38"
                     Height="38"
                     HorizontalAlignment="Center"
@@ -493,14 +533,14 @@
                     CornerRadius="30">
                     <FontIcon
                         x:Name="IconPrevious"
-                        FontSize="13"
+                        FontSize="14"
                         Glyph="&#xE892;" />
                 </Button>
                 <Button
                     x:Name="BtnPlayStateChange"
-                    Grid.Column="4"
-                    Width="52"
-                    Height="52"
+                    Grid.Column="3"
+                    Width="40"
+                    Height="40"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     AutomationProperties.AcceleratorKey="Space"
@@ -513,13 +553,13 @@
                     <FontIcon
                         x:Name="PlayStateIcon"
                         FontFamily="{StaticResource SymbolThemeFontFamily}"
-                        FontSize="20"
+                        FontSize="16"
                         Glyph="&#xEDB5;" />
                     <!--  EDB4  -->
                 </Button>
                 <Button
                     x:Name="BtnNextSong"
-                    Grid.Column="5"
+                    Grid.Column="4"
                     Width="40"
                     Height="40"
                     HorizontalAlignment="Center"
@@ -529,11 +569,11 @@
                     BorderThickness="0"
                     Click="BtnNextSong_OnClick"
                     CornerRadius="30">
-                    <FontIcon FontSize="13" Glyph="&#xE101;" />
+                    <FontIcon FontSize="14" Glyph="&#xE101;" />
                 </Button>
                 <Button
                     x:Name="BtnLike"
-                    Grid.Column="6"
+                    Grid.Column="5"
                     Width="40"
                     Height="40"
                     HorizontalAlignment="Center"
@@ -547,67 +587,25 @@
                         FontSize="14"
                         Glyph="&#xE00B;" />
                 </Button>
-            </Grid>
-            <Grid
-                x:Name="PlayProgress"
-                Grid.Row="1"
-                ColumnSpacing="5">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock
-                    x:Name="TextBlockTotalTime"
-                    Grid.Column="3"
-                    Margin="5,5,0,0"
-                    controls:DockPanel.Dock="Right" />
-                <Border Grid.Column="1" Padding="5,0,5,0">
-                    <Slider
-                        x:Name="SliderProgress"
-                        Margin="-5,0,-5,0"
-                        ValueChanged="SliderProgress_ValueChanged">
-                        <Slider.ThumbToolTipValueConverter>
-                            <local:ThumbConverter SecondValue="{Binding SecondValue}" />
-
-                        </Slider.ThumbToolTipValueConverter>
-                    </Slider>
-                </Border>
-                <TextBlock
-                    x:Name="TextBlockNowTime"
-                    Grid.Column="0"
-                    Margin="0,5,5,0"
-                    controls:DockPanel.Dock="Left" />
-
-            </Grid>
-        </Grid>
-        <controls:UniformGrid
-            x:Name="Btns"
-            Grid.Column="2"
-            Margin="50,0,0,0"
-            HorizontalAlignment="Right"
-            ColumnSpacing="20"
-            Columns="3"
-            CornerRadius="20">
-            <ToggleButton
+                <ToggleButton
                 x:Name="ButtonDesktopLyrics"
+                    Grid.Column="10"
                 Width="40"
                 Height="40"
-                Padding="-5"
                 HorizontalAlignment="Center"
                 Background="Transparent"
                 BorderBrush="Transparent"
                 Click="ToggleButton_Click"
-                FontSize="18"
                 CornerRadius="20"
                 FontWeight="SemiBold"
                 IsChecked="{x:Bind Mode=OneWay, Path=hy:Common.Setting.toastLyric}"
                 IsThreeState="False"
                 ToolTipService.ToolTip="桌面歌词" >
-                <FontIcon Glyph="&#xE66C;"/>
-            </ToggleButton>
-            <Button
+                    <FontIcon Glyph="&#xE66C;" FontSize="14"/>
+                </ToggleButton>
+                <Button
                 x:Name="BtnVolume"
+                    Grid.Column="11"
                 Width="40"
                 Height="40"
                 Padding="-5"
@@ -616,11 +614,12 @@
                 BorderBrush="Transparent"
                 CornerRadius="20"
                 Flyout="{StaticResource VolumeFlyout}">
-                <FontIcon x:Name="BtnVolIcon" Glyph="&#xE15D;" />
-                <!--  E198  -->
-            </Button>
-            <Button
+                    <FontIcon x:Name="BtnVolIcon" Glyph="&#xE15D;"  FontSize="16"/>
+                    <!--  E198  -->
+                </Button>
+                <Button
                 x:Name="ButtonPlayList"
+                    Grid.Column="12"
                 Width="40"
                 Height="40"
                 Padding="-5"
@@ -629,11 +628,11 @@
                 BorderBrush="Transparent"
                 Click="ButtonPlayList_OnClick"
                 CornerRadius="20"  >
-                <Button.Flyout>
-                    <Flyout>
-                        <StackPanel Orientation="Vertical">
-                            <controls:DockPanel LastChildFill="True">
-                                <TextBlock
+                    <Button.Flyout>
+                        <Flyout>
+                            <StackPanel Orientation="Vertical">
+                                <controls:DockPanel LastChildFill="True">
+                                    <TextBlock
                                     x:Name="PlayListTitle"
                                     Margin="16,0,0,0"
                                     DoubleTapped="PlayListTitle_DoubleTapped"
@@ -642,33 +641,33 @@
                                     HorizontalTextAlignment="Center"
                                     IsDoubleTapEnabled="True"
                                     Text="播放列表" />
-                                <Button
+                                    <Button
                                     Margin="5,-5,10,5"
                                     controls:DockPanel.Dock="Right"
                                     Click="ButtonCleanAll_OnClick"
                                     Content="清除"
                                     Foreground="OrangeRed"/>
-                                <Button
+                                    <Button
                                     Margin="0,-5,0,5"
                                     HorizontalAlignment="Right"
                                     controls:DockPanel.Dock="Right"
                                     Click="ButtonAddLocal_OnClick"
                                     Content="添加本地"/>
-                            </controls:DockPanel>
-                            <ListView
+                                </controls:DockPanel>
+                                <ListView
                                 x:Name="ListBoxPlayList"
                                 Width="400"
                                 Height="500"
                                 SelectionChanged="ListBoxPlayList_OnSelectionChanged"
                                 SelectionMode="Single">
-                                <ListView.ItemTemplate>
-                                    <DataTemplate x:DataType="classes:HyPlayItem">
-                                        <StackPanel Margin="0,5,0,5" Orientation="Horizontal">
-                                            <StackPanel Width="345" Orientation="Vertical">
-                                                <TextBlock FontWeight="Bold" Text="{x:Bind Path=PlayItem.Name}" />
-                                                <TextBlock Foreground="{StaticResource SystemControlForegroundBaseMediumBrush}" Text="{x:Bind Path=PlayItem.ArtistString}" />
-                                            </StackPanel>
-                                            <Button
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="classes:HyPlayItem">
+                                            <StackPanel Margin="0,5,0,5" Orientation="Horizontal">
+                                                <StackPanel Width="345" Orientation="Vertical">
+                                                    <TextBlock FontWeight="Bold" Text="{x:Bind Path=PlayItem.Name}" />
+                                                    <TextBlock Foreground="{StaticResource SystemControlForegroundBaseMediumBrush}" Text="{x:Bind Path=PlayItem.ArtistString}" />
+                                                </StackPanel>
+                                                <Button
                                                 Width="24"
                                                 Height="24"
                                                 Padding="-5"
@@ -676,27 +675,23 @@
                                                 BorderBrush="Transparent"
                                                 Click="PlayListRemove_OnClick"
                                                 Tag="{x:Bind Path=PlayItem}">
-                                                <FontIcon
+                                                    <FontIcon
                                                     HorizontalAlignment="Left"
                                                     FontSize="16"
                                                     Glyph="&#xE10A;" />
-                                            </Button>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ListView.ItemTemplate>
-                            </ListView>
-                        </StackPanel>
-                    </Flyout>
-                </Button.Flyout>
-                <FontIcon Glyph="&#xE142;" />
-            </Button>
-            <controls:UniformGrid.RenderTransform>
-                <TranslateTransform x:Name="BtnsAni" />
-            </controls:UniformGrid.RenderTransform>
-        </controls:UniformGrid>
-        <Button
+                                                </Button>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                    <FontIcon Glyph="&#xE142;" FontSize="16" />
+                </Button>
+                <Button
             x:Name="ButtonExpand"
-            Grid.Column="3"
+            Grid.Column="13"
             Width="40"
             Height="40"
             Padding="-5"
@@ -705,14 +700,14 @@
             CornerRadius="20"
             Background="Transparent"
             BorderBrush="Transparent">
-            <FontIcon FontSize="24" Glyph="&#xE971;" />
-            <Button.RenderTransform>
-                <TranslateTransform x:Name="BtnExpandAni" />
-            </Button.RenderTransform>
-        </Button>
-        <Button
+                    <FontIcon FontSize="20" Glyph="&#xE971;" />
+                    <Button.RenderTransform>
+                        <TranslateTransform x:Name="BtnExpandAni" />
+                    </Button.RenderTransform>
+                </Button>
+                <Button
             x:Name="ButtonCollapse"
-            Grid.Column="3"
+            Grid.Column="13"
             Width="40"
             Height="40"
             Padding="-5"
@@ -722,11 +717,13 @@
             Click="ButtonCollapse_OnClick"
             CornerRadius="20"
             Visibility="Collapsed">
-            <FontIcon FontSize="24" Glyph="&#xE972;" />
-        </Button>
+                    <FontIcon FontSize="20" Glyph="&#xE972;" />
+                </Button>
+            </Grid>
+        </Grid>
 
 
-        <VisualStateManager.VisualStateGroups>
+        <!-- VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
                 <VisualState>
                     <VisualState.StateTriggers>
@@ -840,6 +837,6 @@
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
+        </VisualStateManager.VisualStateGroups!-->
     </Grid>
 </UserControl>

--- a/HyPlayer/Controls/PlayBar.xaml.cs
+++ b/HyPlayer/Controls/PlayBar.xaml.cs
@@ -719,6 +719,13 @@ public sealed partial class PlayBar
 
     public void ShowExpandedPlayer()
     {
+        Common.PageMain.GridPlayBar.Margin = new Thickness(16);
+        PlayProgress.Margin = new Thickness(15, 80, 8, 0);
+        Blank.Width = new GridLength(3,GridUnitType.Star );
+        Blank1.Width = new GridLength(1, GridUnitType.Star);
+        Blank2.Width = new GridLength(1, GridUnitType.Star);
+        Blank3.Width = new GridLength(1, GridUnitType.Star);
+        Blank4.Width = new GridLength(1, GridUnitType.Star);
         ButtonExpand.Visibility = Visibility.Collapsed;
         ButtonCollapse.Visibility = Visibility.Visible;
         Common.PageMain.GridPlayBar.Background = null;
@@ -762,6 +769,13 @@ public sealed partial class PlayBar
 
     public void CollapseExpandedPlayer()
     {
+        Common.PageMain.GridPlayBar.Margin = new Thickness(336,16,16,16);
+        PlayProgress.Margin = new Thickness(115, 80, 8, 0);
+        Blank.Width = new GridLength(6, GridUnitType.Star);
+        Blank1.Width = new GridLength(0);
+        Blank2.Width = new GridLength(0);
+        Blank3.Width=new GridLength(0);
+        Blank4.Width = new GridLength(0);
         if (Common.PageExpandedPlayer == null) return;
         Common.PageExpandedPlayer.StartCollapseAnimation();
         GridSongAdvancedOperation.Visibility = Visibility.Collapsed;
@@ -1140,7 +1154,6 @@ public sealed partial class PlayBar
 
     private async void UserControl_Loaded(object sender, RoutedEventArgs e)
     {
-        InitializedAni.Begin();
         PlayBarBackgroundFadeIn.Begin();
         HyPlayList.PlayerOutgoingVolume = (double)Common.Setting.Volume / 100;
         SliderAudioRate.Value = HyPlayList.PlayerOutgoingVolume * 100;
@@ -1281,7 +1294,7 @@ public class PlayBarImageRadiusConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        return value is true ? new CornerRadius(8) : new CornerRadius(8, 0, 0, 0);
+        return value is true ? new CornerRadius(8) : new CornerRadius(8, 8, 0, 0);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/HyPlayer/MainPage.xaml
+++ b/HyPlayer/MainPage.xaml
@@ -38,6 +38,30 @@
                         <Setter Target="GridPlayBar.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="650" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="GridPlayBar.Margin" Value="66,16,16,16" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="1000" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="GridPlayBar.Margin" Value="336,16,16,16" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="200" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="GridPlayBar.Margin" Value="16,16,16,16" />
+                    </VisualState.Setters>
+                </VisualState>
 
                 <VisualState>
                     <VisualState.StateTriggers>

--- a/HyPlayer/MainPage.xaml.cs
+++ b/HyPlayer/MainPage.xaml.cs
@@ -71,7 +71,7 @@ public class PlayBarMarginConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        return value is true ? new Thickness(16) : new Thickness(0);
+        return value is true ? new Thickness(336,16,16,16) : new Thickness(320,0,0,0);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/HyPlayer/Pages/BasePage.xaml
+++ b/HyPlayer/Pages/BasePage.xaml
@@ -201,7 +201,6 @@
                     FontWeight="ExtraBlack"
                     Tag="PageSettings"
                     Tapped="NavigationViewItem_Tapped" />
-                <muxc:NavigationViewItem x:Name="NavItemBlank" x:FieldModifier="public" IsEnabled="False" Height="130" />
             </muxc:NavigationView.FooterMenuItems>
             <Grid>
                 <Frame x:Name="BaseFrame" Grid.Row="1" Margin="0,48,0,0"/>


### PR DESCRIPTION
**### 新版playbar**
（视觉上）脱离左侧NavigationView，仅在BaseFrame中显示

**目前已实现的功能**

1. 不同窗口下Playbar的Margin响应式（Mainpage中的响应式）
<img width="1280" alt="屏幕截图 2022-09-07 174252" src="https://user-images.githubusercontent.com/102895304/188849778-c8976cb2-6326-4bf2-a5ef-1fca22634cc3.png">
<img width="708" alt="屏幕截图 2022-09-07 174234" src="https://user-images.githubusercontent.com/102895304/188849834-63515e07-26bf-4ee1-af45-73b67e92f84e.png">
<img width="370" alt="屏幕截图 2022-08-30 200711" src="https://user-images.githubusercontent.com/102895304/188849867-0e925d02-6b73-4c40-969d-fbca47eea344.png">

2.所有按钮全部移入MainControlGrid并置右
<img width="1035" alt="屏幕截图 2022-09-07 1742521" src="https://user-images.githubusercontent.com/102895304/188850406-b682cbaa-68bc-4888-af34-e3fa39241500.png">

3.Expandedplayer布局
<img width="1280" alt="屏幕截图 2022-09-07 174309" src="https://user-images.githubusercontent.com/102895304/188857313-215ad5ce-d9e9-419b-aada-f01f769deafb.png">


**有待实现功能**
1.加入开关保证原样式与新版样式之间的切换
2.响应式的优化
3.按钮样式的优化


**因部分改动而删除的功能**
1.响应式（防止因改动（头脑混乱）而出现Bug）
2.按钮背景以及播放按钮强调色（因删除响应式后窗口宽度过小会导致按钮背景显示不全）
3.BtnsAni因整合至MainControlGrid而删除


**已知Issues**

1.Expandedplayer下按钮布局与响应式冲突导致更改窗口宽度时Playbar的Margin不正确
2.只适配了Playbar脱离窗口模式（关闭脱离窗口几乎失效）
3.可能还有更多...

因个人能力有限，目前还是半成品，有待后续优化，部分Issues和有待解决功能因能力有限，望帮助解决，thk

### **希望可以Merge到一个新开branch**
