### PR TITLE
重写了渐入渐出方法来修复暂停后切歌会无声音的问题

### DIFF
--- a/HyPlayer/Controls/PlayBar.xaml.cs
+++ b/HyPlayer/Controls/PlayBar.xaml.cs
@@ -47,7 +47,7 @@ public sealed partial class PlayBar
     private SolidColorBrush BackgroundElayBrush = new(Colors.Transparent);
     private bool canslide;
 
-    private long FadeInOutStartTime;
+    public static long FadeInOutStartTime;
     private double FadeInOutLastVolume;
     private double FadeTime;
     private bool PlayorNext;

--- a/HyPlayer/HyPlayControl/HyPlayList.cs
+++ b/HyPlayer/HyPlayControl/HyPlayList.cs
@@ -706,6 +706,7 @@ public static class HyPlayList
         {
             await ms.OpenAsync();
             Player.Source = ms;
+            PlayBar.FadeInOutStartTime = DateTime.Now.Ticks;
         }
         catch (Exception e)
         {

--- a/HyPlayer/HyPlayControl/HyPlayList.cs
+++ b/HyPlayer/HyPlayControl/HyPlayList.cs
@@ -82,19 +82,19 @@ public static class HyPlayList
     private static string _crashedTime;
 
     public static string PlaySourceId;
-    private static double _playerOutgoingVolume;
-
-    public static double PlayerOutgoingVolume
+    private static double _userVolume;
+    public static double UserVolume
     {
-        get => _playerOutgoingVolume;
+        get => _userVolume;
         set
         {
-            _playerOutgoingVolume = value;
-            Player.Volume = _playerOutgoingVolume;
+            _userVolume = value;
             Common.Setting.Volume = (int)(value * 100);
-            OnVolumeChange?.Invoke(_playerOutgoingVolume);
         }
     }
+    public static double FadeVolume;
+
+    public static double FadeTargetVolume;
 
     /*********        基本       ********/
     public static PlayMode NowPlayType

--- a/HyPlayer/HyPlayControl/HyPlayList.cs
+++ b/HyPlayer/HyPlayControl/HyPlayList.cs
@@ -21,6 +21,7 @@ using NeteaseCloudMusicApi;
 using Newtonsoft.Json.Linq;
 using Opportunity.LrcParser;
 using File = TagLib.File;
+using HyPlayer.Controls;
 
 #endregion
 
@@ -93,8 +94,6 @@ public static class HyPlayList
         }
     }
     public static double FadeVolume;
-
-    public static double FadeTargetVolume;
 
     /*********        基本       ********/
     public static PlayMode NowPlayType

--- a/HyPlayer/HyPlayer.csproj
+++ b/HyPlayer/HyPlayer.csproj
@@ -39,6 +39,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>

--- a/HyPlayer/Pages/ExpandedPlayer.xaml.cs
+++ b/HyPlayer/Pages/ExpandedPlayer.xaml.cs
@@ -687,7 +687,7 @@ public sealed partial class ExpandedPlayer : Page, IDisposable
         if (loaded)
         {
             Common.BarPlayBar.SliderAudioRate.Value = e.NewValue;
-            HyPlayList.PlayerOutgoingVolume = e.NewValue / 100;
+            HyPlayList.UserVolume = e.NewValue / 100;
         }
     }
 

--- a/HyPlayer/Pages/Settings.xaml
+++ b/HyPlayer/Pages/Settings.xaml
@@ -253,13 +253,13 @@
                                             VerticalAlignment="Center"
                                             IsOn="{x:Bind hyplayer:Common.Setting.fadeInOutPause, Mode=TwoWay}" />
                                     </Grid>-->
-                                    <Grid Visibility="{x:Bind hyplayer:Common.Setting.fadeInOutPause, Mode=OneWay}">
+                                    <Grid Visibility="{x:Bind hyplayer:Common.Setting.fadeInOut, Mode=OneWay}">
                                         <TextBlock VerticalAlignment="Center" Text="播放渐入渐出时间 单位: 0.1s" />
                                         <Slider
                                             x:Name="FadeTimePause"
                                             Width="256"
                                             HorizontalAlignment="Right"
-                                            IsEnabled="{x:Bind hyplayer:Common.Setting.fadeInOutPause, Mode=OneWay}"
+                                            IsEnabled="{x:Bind hyplayer:Common.Setting.fadeInOut, Mode=OneWay}"
                                             Maximum="50"
                                             Minimum="1"
                                             ToolTipService.ToolTip="{x:Bind FadeTimePause.Value}"

--- a/HyPlayer/Pages/Settings.xaml
+++ b/HyPlayer/Pages/Settings.xaml
@@ -226,7 +226,7 @@
                                 </controls:Expander.Transitions>
                                 <StackPanel Orientation="Vertical" Spacing="8">
                                     <Grid>
-                                        <TextBlock VerticalAlignment="Center" Text="切歌时" />
+                                        <TextBlock VerticalAlignment="Center" Text="启用渐入渐出" />
                                         <ToggleSwitch
                                             x:Name="FadeInOut"
                                             MinWidth="10"
@@ -241,27 +241,27 @@
                                             HorizontalAlignment="Right"
                                             IsEnabled="{x:Bind hyplayer:Common.Setting.fadeInOut, Mode=OneWay}"
                                             Maximum="12"
-                                            Minimum="0"
+                                            Minimum="1"
                                             ToolTipService.ToolTip="{x:Bind FadeTime.Value}"
                                             Value="{x:Bind hyplayer:Common.Setting.fadeInOutTime, Mode=TwoWay}" />
                                     </Grid>
-                                    <Grid>
+                                    <!--<Grid>
                                         <TextBlock VerticalAlignment="Center" Text="播放暂停时" />
                                         <ToggleSwitch
                                             MinWidth="10"
                                             HorizontalAlignment="Right"
                                             VerticalAlignment="Center"
                                             IsOn="{x:Bind hyplayer:Common.Setting.fadeInOutPause, Mode=TwoWay}" />
-                                    </Grid>
+                                    </Grid>-->
                                     <Grid Visibility="{x:Bind hyplayer:Common.Setting.fadeInOutPause, Mode=OneWay}">
-                                        <TextBlock VerticalAlignment="Center" Text="渐入渐出时间 单位: 0.1s" />
+                                        <TextBlock VerticalAlignment="Center" Text="播放渐入渐出时间 单位: 0.1s" />
                                         <Slider
                                             x:Name="FadeTimePause"
                                             Width="256"
                                             HorizontalAlignment="Right"
                                             IsEnabled="{x:Bind hyplayer:Common.Setting.fadeInOutPause, Mode=OneWay}"
                                             Maximum="50"
-                                            Minimum="0"
+                                            Minimum="1"
                                             ToolTipService.ToolTip="{x:Bind FadeTimePause.Value}"
                                             Value="{x:Bind hyplayer:Common.Setting.fadeInOutTimePause, Mode=TwoWay}" />
                                     </Grid>


### PR DESCRIPTION
几乎完全重写了渐入渐出方法
播放暂停交由渐入渐出管理
修改了播放键的UI逻辑使图标与进行中的状态匹配
将渐入渐出修改为仅单个总开关
为避免除以0的情况将渐入渐出最小值修改为1

(刚接触C#搭上UWP环境没几天,代码质量可能会比较差,Code Style也可能与HyPlayer原本的不太相同,请酌情修改代码)