### PR TITLE
修复当无声音输出设备时无限切换下一首的错误

### DIFF
--- a/HyPlayer/HyPlayControl/HyPlayList.cs
+++ b/HyPlayer/HyPlayControl/HyPlayList.cs
@@ -326,7 +326,14 @@ public static class HyPlayList
     {
         //歌曲崩溃了的话就是这个
         //SongMoveNext();
+
         Common.ErrorMessageList.Add("歌曲" + NowPlayingItem.PlayItem.Name + " 播放失败: " + reason);
+
+        if (reason.Contains("mediasink",StringComparison.OrdinalIgnoreCase))
+        {
+            Common.AddToTeachingTipLists("播放失败","无法创建媒体接收器，请检查设备是否有声音输出设备！");
+            return;
+        }
 
         Common.AddToTeachingTipLists("播放失败 切到下一曲",
             "歌曲" + NowPlayingItem.PlayItem.Name + "\r\n" + reason);


### PR DESCRIPTION
设备无声音输出设备时会触发错误自动切换下一首，但是切换下一首后会继续触发错误从而导致无限下一首，从而占据资源导致卡顿等问题，此改动检测到错误为无声音输出设备时会停止自动切换下一首